### PR TITLE
Add new ASCP version

### DIFF
--- a/empiar/__init__.py
+++ b/empiar/__init__.py
@@ -48,12 +48,13 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def defineBinaries(cls, env):
-        empiar_cmd = [('./ibm-aspera-connect_4.2.11.768_linux_x86_64.sh', [])]
-        url = 'https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.11.768_linux_x86_64.tar.gz'
-        env.addPackage('ascp', version="4.2.11",
+        empiar_cmd = [('./ibm-aspera-connect_4.2.12.780_linux_x86_64.tar.gz', [])]
+        # url = 'https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.11.768_linux_x86_64.tar.gz'
+        url = 'https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.12.780_linux_x86_64.tar.gz'
+        env.addPackage('ascp', version="4.2.12",
                        url=url,
                        default=True,
                        buildDir='ascp',
                        createBuildDir=True,
-                       target='ascp/ibm-aspera-connect_4.2.11.768_linux_x86_64.sh',
+                       target='ascp/ibm-aspera-connect_4.2.12.780_linux_x86_64.tar.gz',
                        commands=empiar_cmd)

--- a/empiar/__init__.py
+++ b/empiar/__init__.py
@@ -49,7 +49,6 @@ class Plugin(pwem.Plugin):
     @classmethod
     def defineBinaries(cls, env):
         empiar_cmd = [('./ibm-aspera-connect_4.2.12.780_linux_x86_64.sh', [])]
-        # url = 'https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.11.768_linux_x86_64.tar.gz'
         url = 'https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.12.780_linux_x86_64.tar.gz'
         env.addPackage('ascp', version="4.2.12",
                        url=url,

--- a/empiar/__init__.py
+++ b/empiar/__init__.py
@@ -48,7 +48,7 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def defineBinaries(cls, env):
-        empiar_cmd = [('./ibm-aspera-connect_4.2.12.780_linux_x86_64.tar.gz', [])]
+        empiar_cmd = [('./ibm-aspera-connect_4.2.12.780_linux_x86_64.sh', [])]
         # url = 'https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.11.768_linux_x86_64.tar.gz'
         url = 'https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.12.780_linux_x86_64.tar.gz'
         env.addPackage('ascp', version="4.2.12",
@@ -56,5 +56,5 @@ class Plugin(pwem.Plugin):
                        default=True,
                        buildDir='ascp',
                        createBuildDir=True,
-                       target='ascp/ibm-aspera-connect_4.2.12.780_linux_x86_64.tar.gz',
+                       target='ascp/ibm-aspera-connect_4.2.12.780_linux_x86_64.sh',
                        commands=empiar_cmd)


### PR DESCRIPTION
ASCP version 4.2.11 was no longer available in the server, giving 404 and failing on the installation of the binaries. I just added the new link so it downloads an available version (current is 4.2.12).